### PR TITLE
Add historical QCon data migration

### DIFF
--- a/.github/workflows/scheduled-backfill.yml
+++ b/.github/workflows/scheduled-backfill.yml
@@ -68,6 +68,25 @@ jobs:
       - name: Validate before writes
         run: uv run --extra dev pytest -q
 
+      - name: Preview next historical crawl source
+        run: |
+          uv run python scripts/migrate_historical_qcon.py \
+            --start-year "$START_YEAR" \
+            --end-year "$END_YEAR" \
+            --max-sources 1 \
+            --max-pages 1 \
+            --dry-run
+
+      - name: Migrate next historical crawl source
+        if: env.DRY_RUN == 'false'
+        run: |
+          uv run python scripts/migrate_historical_qcon.py \
+            --start-year "$START_YEAR" \
+            --end-year "$END_YEAR" \
+            --max-sources 1 \
+            --max-pages 1 \
+            --enrich-details
+
       - name: Preview next scheduled batch
         run: |
           uv run infoq-watchlist github-backfill \

--- a/README.md
+++ b/README.md
@@ -439,15 +439,19 @@ Avoid backfilling many years in one write run. Smaller batches reduce GitHub rat
 
 `.github/workflows/scheduled-backfill.yml` runs every 90 minutes and processes one small GitHub batch per run.
 
-The scheduled job walks from the newest configured year toward older material, defaulting to `2025` down to `2016`. Each run:
+The scheduled job walks from the newest configured year toward older material, defaulting to `2025` down to `2016`. Each write run:
 
-1. previews the next SQLite-backed batch with `github-backfill --dry-run`
-2. repairs created issues that are missing GitHub Project item ids
-3. creates up to the configured limit of new issues
-4. runs database maintenance and tests
-5. commits and pushes `data/infoq.db`
+1. previews the next historical QCon archive source with `scripts/migrate_historical_qcon.py --dry-run`
+2. migrates one not-yet-attempted archive source into SQLite
+3. previews the next SQLite-backed batch with `github-backfill --dry-run`
+4. repairs created issues that are missing GitHub Project item ids
+5. creates up to the configured limit of new issues
+6. runs database maintenance and tests
+7. commits and pushes `data/infoq.db`
 
 Manual dispatches default to `dry_run=true`. Scheduled runs write by default. If GitHub returns a rate-limit error, the workflow still commits any partial SQLite sync state before reporting the rate-limit failure.
+
+The historical migration script records source-level progress in `historical_crawl_state`, so each scheduled run can continue from the next QCon archive URL instead of recrawling the same source.
 
 ### Weekly Watchlist
 

--- a/infoq_watchlist/migrations/005_add_historical_crawl_state.sql
+++ b/infoq_watchlist/migrations/005_add_historical_crawl_state.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS historical_crawl_state (
+  source_url TEXT PRIMARY KEY,
+  year INTEGER NOT NULL,
+  source_name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  row_count INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  attempted_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_historical_crawl_state_year_status
+ON historical_crawl_state(year, status);

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repo-local operational scripts."""

--- a/scripts/migrate_historical_qcon.py
+++ b/scripts/migrate_historical_qcon.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import timezone, datetime
+from pathlib import Path
+from typing import Iterable
+
+from infoq_watchlist.config import load_config
+from infoq_watchlist.crawler import discover_listing_urls, fetch_url
+from infoq_watchlist.migrations import migrate_db
+from infoq_watchlist.parser import merge_detail, parse_detail, parse_listing, parse_schedule_links
+from infoq_watchlist.scoring import score_talk
+from infoq_watchlist.storage import upsert_talk
+
+
+DEFAULT_DB = Path("data/infoq.db")
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalSource:
+    """One QCon archive URL that can seed SQLite rows."""
+
+    year: int
+    source_name: str
+    url: str
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationResult:
+    """Serializable result for one attempted historical source."""
+
+    source: HistoricalSource
+    status: str
+    row_count: int
+    error: str | None = None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run a bounded historical crawl migration."""
+    args = _build_parser().parse_args(argv)
+    sources = list_pending_sources(
+        args.db,
+        start_year=args.start_year,
+        end_year=args.end_year,
+        limit=args.max_sources,
+        retry_failed=args.retry_failed,
+    )
+
+    if args.dry_run:
+        # Dry-run prints the exact source URLs the next write run will attempt.
+        print(json.dumps({"mode": "dry-run", "count": len(sources), "sources": [asdict(source) for source in sources]}, indent=2))
+        return 0
+
+    results: list[MigrationResult] = []
+    for source in sources:
+        result = migrate_source(
+            args.db,
+            source,
+            config_path=args.config,
+            max_pages=args.max_pages,
+            enrich_details=args.enrich_details,
+        )
+        record_source_state(args.db, result)
+        results.append(result)
+
+    print(json.dumps({"mode": "write", "count": len(results), "results": [_result_dict(result) for result in results]}, indent=2))
+    return 0
+
+
+def list_pending_sources(
+    db_path: str | Path,
+    start_year: int,
+    end_year: int,
+    limit: int,
+    retry_failed: bool = False,
+) -> list[HistoricalSource]:
+    """Return latest-first QCon archive sources that still need migration."""
+    attempted = _attempted_source_urls(db_path, retry_failed=retry_failed)
+    pending = [source for source in iter_historical_sources(start_year, end_year) if source.url not in attempted]
+    return pending[:limit]
+
+
+def iter_historical_sources(start_year: int, end_year: int) -> Iterable[HistoricalSource]:
+    """Generate known QCon archive URL patterns newest year first."""
+    for year in range(end_year, start_year - 1, -1):
+        # QCon SF is late-year, then New York, then London, so this is roughly
+        # reverse calendar order within each year.
+        yield HistoricalSource(year, "qcon-sf", f"https://www.infoq.com/conferences/qconsf{year}/")
+        yield HistoricalSource(year, "qcon-newyork", f"https://www.infoq.com/qcon-newyork-{year}/")
+        yield HistoricalSource(year, "qcon-london", f"https://www.infoq.com/qcon-london-{year}/")
+
+
+def migrate_source(
+    db_path: str | Path,
+    source: HistoricalSource,
+    config_path: str,
+    max_pages: int,
+    enrich_details: bool,
+) -> MigrationResult:
+    """Crawl one source URL, score rows, and upsert them into SQLite."""
+    config = load_config(config_path)
+    try:
+        row_count = 0
+        for html, base_url in _fetch_pages(source.url, max_pages=max_pages):
+            talks = parse_listing(html, base_url=base_url)
+            if not talks:
+                talks = parse_schedule_links(html, base_url=base_url)
+            for talk in talks:
+                if enrich_details:
+                    # Detail fetches improve titles/speakers but should not
+                    # discard a row when one detail page is temporarily flaky.
+                    talk = _enrich_or_keep(talk)
+                upsert_talk(db_path, score_talk(talk, config))
+                row_count += 1
+        return MigrationResult(source=source, status="success", row_count=row_count)
+    except Exception as exc:
+        # Record failed sources so the scheduled migration can continue to the
+        # next archive URL; reruns can opt into --retry-failed.
+        return MigrationResult(source=source, status="failed", row_count=0, error=str(exc)[:500])
+
+
+def record_source_state(db_path: str | Path, result: MigrationResult) -> None:
+    """Persist an attempted source URL so future runs can resume."""
+    migrate_db(db_path)
+    attempted_at = datetime.now(timezone.utc).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO historical_crawl_state (
+              source_url, year, source_name, status, row_count, error, attempted_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_url) DO UPDATE SET
+              status = excluded.status,
+              row_count = excluded.row_count,
+              error = excluded.error,
+              attempted_at = excluded.attempted_at
+            """,
+            (
+                result.source.url,
+                result.source.year,
+                result.source.source_name,
+                result.status,
+                result.row_count,
+                result.error,
+                attempted_at,
+            ),
+        )
+
+
+def _fetch_pages(seed_url: str, max_pages: int) -> list[tuple[str, str]]:
+    """Fetch a seed page and bounded pagination pages."""
+    pages: list[tuple[str, str]] = []
+    fetched_urls: set[str] = set()
+    seed_html = fetch_url(seed_url)
+    pages.append((seed_html, seed_url))
+    fetched_urls.add(seed_url.rstrip("/"))
+    for page_url in discover_listing_urls(seed_url, seed_html, max_pages):
+        key = page_url.rstrip("/")
+        if key in fetched_urls:
+            continue
+        pages.append((fetch_url(page_url), page_url))
+        fetched_urls.add(key)
+    return pages
+
+
+def _enrich_or_keep(talk):
+    """Return detail-enriched metadata, falling back to the listing row."""
+    detail_url = talk.presentation_url or talk.url
+    try:
+        return merge_detail(talk, parse_detail(fetch_url(detail_url), detail_url))
+    except Exception:
+        return talk
+
+
+def _attempted_source_urls(db_path: str | Path, retry_failed: bool) -> set[str]:
+    """Read source URLs that should be skipped on this run."""
+    # Failed sources are normally skipped so automation keeps moving; manual
+    # repair runs can retry them while still skipping successful sources.
+    where = "WHERE status = 'success'" if retry_failed else ""
+    if not Path(db_path).exists():
+        return set()
+    with sqlite3.connect(db_path) as conn:
+        try:
+            rows = conn.execute(f"SELECT source_url FROM historical_crawl_state {where}").fetchall()
+        except sqlite3.OperationalError:
+            return set()
+    return {row[0] for row in rows}
+
+
+def _result_dict(result: MigrationResult) -> dict[str, object]:
+    """Flatten nested dataclasses for JSON output."""
+    return {
+        "source": asdict(result.source),
+        "status": result.status,
+        "row_count": result.row_count,
+        "error": result.error,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Define script arguments without adding another CLI dependency."""
+    parser = argparse.ArgumentParser(prog="migrate_historical_qcon")
+    parser.add_argument("--config", default="watchlist.toml")
+    parser.add_argument("--db", default=str(DEFAULT_DB))
+    parser.add_argument("--start-year", type=int, default=2016)
+    parser.add_argument("--end-year", type=int, default=2025)
+    parser.add_argument("--max-sources", type=int, default=1)
+    parser.add_argument("--max-pages", type=int, default=1)
+    parser.add_argument("--enrich-details", action="store_true")
+    parser.add_argument("--retry-failed", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_historical_migration_script.py
+++ b/tests/test_historical_migration_script.py
@@ -1,0 +1,110 @@
+import json
+import sqlite3
+
+from scripts import migrate_historical_qcon as historical
+
+from infoq_watchlist.storage import list_talks
+
+
+def test_iter_historical_sources_walks_newest_year_first():
+    sources = list(historical.iter_historical_sources(2024, 2025))
+
+    # Backfill discovery should start from the newest year and late-year event.
+    assert [source.url for source in sources[:4]] == [
+        "https://www.infoq.com/conferences/qconsf2025/",
+        "https://www.infoq.com/qcon-newyork-2025/",
+        "https://www.infoq.com/qcon-london-2025/",
+        "https://www.infoq.com/conferences/qconsf2024/",
+    ]
+
+
+def test_pending_sources_skip_attempted_urls_and_can_retry_failures(tmp_path):
+    db_path = tmp_path / "infoq.db"
+    success = historical.MigrationResult(
+        source=historical.HistoricalSource(2025, "qcon-sf", "https://www.infoq.com/conferences/qconsf2025/"),
+        status="success",
+        row_count=2,
+    )
+    failed = historical.MigrationResult(
+        source=historical.HistoricalSource(2025, "qcon-newyork", "https://www.infoq.com/qcon-newyork-2025/"),
+        status="failed",
+        row_count=0,
+        error="not found",
+    )
+    historical.record_source_state(db_path, success)
+    historical.record_source_state(db_path, failed)
+
+    default_pending = historical.list_pending_sources(db_path, start_year=2025, end_year=2025, limit=3)
+    retry_pending = historical.list_pending_sources(
+        db_path,
+        start_year=2025,
+        end_year=2025,
+        limit=3,
+        retry_failed=True,
+    )
+
+    # Normal automation skips all attempted sources; repair runs may retry failed sources.
+    assert [source.source_name for source in default_pending] == ["qcon-london"]
+    assert [source.source_name for source in retry_pending] == ["qcon-newyork", "qcon-london"]
+
+
+def test_migrate_source_uses_schedule_links_and_records_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "infoq.db"
+    html = """
+    <html>
+      <body>
+        <a href="/presentations/distributed-runtime/">Distributed Runtime</a>
+        <a href="/presentations/platform-scaling/">Platform Scaling</a>
+      </body>
+    </html>
+    """
+
+    monkeypatch.setattr(historical, "fetch_url", lambda url: html)
+    source = historical.HistoricalSource(2025, "qcon-sf", "https://www.infoq.com/conferences/qconsf2025/")
+
+    result = historical.migrate_source(
+        db_path,
+        source,
+        config_path="watchlist.toml",
+        max_pages=1,
+        enrich_details=False,
+    )
+    historical.record_source_state(db_path, result)
+
+    talks = list_talks(db_path, start_year=2025, end_year=2025)
+    with sqlite3.connect(db_path) as conn:
+        state = conn.execute(
+            "SELECT status, row_count FROM historical_crawl_state WHERE source_url = ?",
+            (source.url,),
+        ).fetchone()
+
+    # Schedule pages without dates still seed rows from their archive year.
+    assert result.status == "success"
+    assert result.row_count == 2
+    assert [talk.title for talk in talks] == ["Distributed Runtime", "Platform Scaling"]
+    assert state == ("success", 2)
+
+
+def test_script_dry_run_prints_next_source(tmp_path, capsys):
+    db_path = tmp_path / "infoq.db"
+
+    exit_code = historical.main(
+        [
+            "--db",
+            str(db_path),
+            "--start-year",
+            "2025",
+            "--end-year",
+            "2025",
+            "--max-sources",
+            "1",
+            "--dry-run",
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+
+    # Dry-runs must be safe previews for manual workflow dispatches.
+    assert exit_code == 0
+    assert output["mode"] == "dry-run"
+    assert output["sources"][0]["url"] == "https://www.infoq.com/conferences/qconsf2025/"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -11,9 +11,9 @@ def test_migrate_db_records_applied_versions(tmp_path):
     second_run = migrate_db(db_path)
 
     # Migration runs should be explicit, recorded, and safe to repeat.
-    assert first_run == ["001", "002", "003", "004"]
+    assert first_run == ["001", "002", "003", "004", "005"]
     assert second_run == []
-    assert current_version(db_path) == "004"
+    assert current_version(db_path) == "005"
 
     with sqlite3.connect(db_path) as conn:
         tables = {
@@ -22,12 +22,13 @@ def test_migrate_db_records_applied_versions(tmp_path):
         }
         migration_rows = conn.execute("SELECT version, name FROM schema_migrations").fetchall()
 
-    assert {"schema_migrations", "talks"}.issubset(tables)
+    assert {"schema_migrations", "talks", "historical_crawl_state"}.issubset(tables)
     assert migration_rows == [
         ("001", "create_talks"),
         ("002", "add_reporting_state"),
         ("003", "add_presentation_url"),
         ("004", "add_github_sync_state"),
+        ("005", "add_historical_crawl_state"),
     ]
 
 
@@ -39,7 +40,7 @@ def test_cli_migrate_creates_database(tmp_path):
     # The CLI should be enough to stand up a fresh SQLite database.
     assert exit_code == 0
     assert db_path.exists()
-    assert current_version(db_path) == "004"
+    assert current_version(db_path) == "005"
 
 
 def test_migrate_db_adds_reporting_state_columns(tmp_path):
@@ -54,8 +55,8 @@ def test_migrate_db_adds_reporting_state_columns(tmp_path):
         }
 
     # Reporting state lets issue publishing be idempotent across runs.
-    assert applied == ["001", "002", "003", "004"]
-    assert current_version(db_path) == "004"
+    assert applied == ["001", "002", "003", "004", "005"]
+    assert current_version(db_path) == "005"
     assert {
         "watch_status",
         "last_reported_at",
@@ -68,3 +69,26 @@ def test_migrate_db_adds_reporting_state_columns(tmp_path):
         "github_project_item_id",
         "last_synced_at",
     }.issubset(talk_columns)
+
+
+def test_migrate_db_adds_historical_crawl_state_table(tmp_path):
+    db_path = tmp_path / "infoq.db"
+
+    migrate_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(historical_crawl_state)").fetchall()
+        }
+
+    # Historical data migration needs durable source-level resume state.
+    assert {
+        "source_url",
+        "year",
+        "source_name",
+        "status",
+        "row_count",
+        "error",
+        "attempted_at",
+    }.issubset(columns)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -43,6 +43,9 @@ def test_scheduled_backfill_runs_every_90_minutes_and_checkpoints_db():
     assert 'cron: "0 0-21/3 * * *"' in workflow
     assert 'cron: "30 1-22/3 * * *"' in workflow
     assert "concurrency:" in workflow
+    assert "scripts/migrate_historical_qcon.py" in workflow
+    assert "Preview next historical crawl source" in workflow
+    assert "Migrate next historical crawl source" in workflow
     assert "github-backfill" in workflow
     assert '--end-year "$END_YEAR"' in workflow
     assert "--create-issues" in workflow


### PR DESCRIPTION
## Summary
- add a historical_crawl_state SQLite migration for source-level crawl resume state
- add scripts/migrate_historical_qcon.py to crawl one latest-first QCon archive source per run
- wire the scheduled backfill workflow to migrate one historical source before syncing issues
- document the scheduled data migration behavior and add coverage for migration/script/workflow behavior

## Verification
- git diff --check
- uv run --extra dev pytest -q
- uv run python scripts/migrate_historical_qcon.py --db data/infoq.db --start-year 2016 --end-year 2025 --max-sources 1 --dry-run
- GitHub Actions CI: passing
