### PR TITLE
fix: point weekly crawl at newest-first InfoQ feeds

### DIFF
--- a/watchlist.toml
+++ b/watchlist.toml
@@ -25,11 +25,14 @@ like_step = 10
 view_step = 1000
 max_bonus = 4
 
+# Newest-first InfoQ feeds so the weekly crawl surfaces recently published talks.
+# Per-edition QCon archive pages (e.g. qconsf2016) are frozen to one year and were
+# the reason the weekly job never found new talks; the every-90-min historical
+# backfill walks those dated archives via scripts/migrate_historical_qcon.py.
 [sources]
 qcon_seed_urls = [
-  "https://www.infoq.com/qcon-london-2016/",
-  "https://www.infoq.com/qcon-newyork-2016/",
-  "https://www.infoq.com/conferences/qconsf2016/",
+  "https://www.infoq.com/presentations/",
+  "https://www.infoq.com/conferences/qconsf",
 ]
 
 [github]


### PR DESCRIPTION
The `weekly-watchlist.yml` job runs `crawl --max-pages 1`, which reads `qcon_seed_urls` from `watchlist.toml`. Those seeds were frozen to three **2016** QCon editions:

```toml
qcon_seed_urls = [
  "https://www.infoq.com/qcon-london-2016/",
  "https://www.infoq.com/qcon-newyork-2016/",
  "https://www.infoq.com/conferences/qconsf2016/",
]
```

So the weekly job re-crawled the same 2016 pages every run and could never surface newly published talks. In practice all new-talk discovery came from the every-90-min historical backfill, not the weekly crawl.

## Fix

Point the weekly crawl at InfoQ newest-first feeds:

```toml
qcon_seed_urls = [
  "https://www.infoq.com/presentations/",
  "https://www.infoq.com/conferences/qconsf",
]
```

## Why this is safe

- `github-sync --recent-days 14` filters candidates on `published_date >= date(now, -14 days)` (`infoq_watchlist/storage.py`), so a broad newest-first feed cannot flood issues with old talks - only the last two weeks become issues.
- `parse_listing` already handles the `/presentations/` layout (used throughout the test fixtures).
- Per-edition dated archives stay covered by `scripts/migrate_historical_qcon.py` (the 90-min backfill), so historical coverage is unchanged.

## Verification

- `uv run pytest -q` -> 51 passed
- `load_config(watchlist.toml).qcon_seed_urls` returns the two new feeds

Config-only; no code or workflow changes.