### PR TITLE
fix: replace dead qconsf seed and skip unreachable listing pages

### DIFF
--- a/infoq_watchlist/cli.py
+++ b/infoq_watchlist/cli.py
@@ -7,6 +7,8 @@ import sqlite3
 from dataclasses import asdict
 from pathlib import Path
 
+import requests
+
 from infoq_watchlist.config import load_config
 from infoq_watchlist.crawler import discover_listing_urls, fetch_url, read_fixture
 from infoq_watchlist.github_sync import (
@@ -397,18 +399,30 @@ def _inside_year_range(year: int | None, start_year: int | None, end_year: int |
 
 
 def _fetch_listing_pages(seed_urls: list[str], max_pages: int) -> list[str]:
-    """Fetch seed pages and statically discovered pagination URLs."""
+    """Fetch seed pages and statically discovered pagination URLs.
+
+    A single dead seed (InfoQ retires/redirects listing pages over time) is
+    skipped with a warning instead of failing the whole crawl.
+    """
     pages: list[tuple[str, str]] = []
     fetched_urls: set[str] = set()
     for seed_url in seed_urls:
-        seed_html = fetch_url(seed_url)
+        try:
+            seed_html = fetch_url(seed_url)
+        except requests.HTTPError as exc:
+            print(f"warning: skipping seed {seed_url}: {exc}")
+            continue
         pages.append((seed_html, seed_url))
         fetched_urls.add(seed_url.rstrip("/"))
         for page_url in discover_listing_urls(seed_url, seed_html, max_pages):
             key = page_url.rstrip("/")
             if key in fetched_urls:
                 continue
-            pages.append((fetch_url(page_url), page_url))
+            try:
+                pages.append((fetch_url(page_url), page_url))
+            except requests.HTTPError as exc:
+                print(f"warning: skipping page {page_url}: {exc}")
+                continue
             fetched_urls.add(key)
     return pages
 

--- a/watchlist.toml
+++ b/watchlist.toml
@@ -32,7 +32,7 @@ max_bonus = 4
 [sources]
 qcon_seed_urls = [
   "https://www.infoq.com/presentations/",
-  "https://www.infoq.com/conferences/qconsf",
+  "https://www.infoq.com/conferences/",
 ]
 
 [github]


### PR DESCRIPTION
## Summary
- The weekly-watchlist Action was failing: InfoQ discontinued `/conferences/qconsf` (now 404s), and `fetch_url()` raises unconditionally on any non-2xx response, crashing the whole crawl step.
- Swapped the dead seed for `https://www.infoq.com/conferences/` (confirmed live, 200).
- Made `_fetch_listing_pages` skip a dead seed/page with a warning instead of crashing the crawl, so a future InfoQ URL change degrades gracefully.

## Test plan
- [x] `uv run --extra dev pytest -q` — 51 passed
- [x] Live crawl against a scratch db (`crawl --max-pages 1`, no fixtures) completes cleanly against the real InfoQ site, parsing 20 talks with no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)